### PR TITLE
Recreate background indexes

### DIFF
--- a/copier.py
+++ b/copier.py
@@ -185,7 +185,7 @@ def copy_indexes(source, dest):
         kwargs = { 'name': name }
         index_key = None
         for k, v in index.items():
-            if k in ['unique', 'sparse']:
+            if k in ['background', 'unique', 'sparse']:
                 kwargs[k] = v
             elif k == 'v':
                 continue


### PR DESCRIPTION
Hydra does not allow the often-used `background` [index option](http://docs.mongodb.org/manual/reference/method/db.collection.createIndex/#options-for-all-index-types).

The one line change in this pull request allows the `background` option when recreating indexes.
